### PR TITLE
Add multi-class support with student management

### DIFF
--- a/Attari.html
+++ b/Attari.html
@@ -76,13 +76,40 @@
 
     <!-- APP -->
     <div id="app" class="hidden">
-      <div class="grid grid-cols-1 xl:grid-cols-5 gap-8">
+      <div class="grid grid-cols-1 xl:grid-cols-5 gap-6">
         <!-- Form Card -->
         <section class="xl:col-span-2">
           <div class="glass bg-white/70 dark:bg-slate-900/70 rounded-3xl shadow-2xl border border-white/20 dark:border-slate-700/30">
-            <div class="p-6 md:p-8 border-b border-slate-200/50 dark:border-slate-700/50 flex items-center justify-between">
-              <h2 class="text-2xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-emerald-600 to-teal-600"><span id="formTitle">✨ New Entry</span></h2>
-              <button id="signOutBtn" class="px-3 py-1.5 rounded-xl ring-1 ring-slate-300 dark:ring-slate-700 text-sm">Sign out</button>
+            <div class="p-6 md:p-8 border-b border-slate-200/50 dark:border-slate-700/50 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 class="text-2xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-emerald-600 to-teal-600"><span id="formTitle">✨ New Entry</span></h2>
+                <p id="classStatus" class="text-xs text-slate-500 dark:text-slate-400 mt-1">Select a class to get started.</p>
+              </div>
+              <button id="signOutBtn" class="px-3 py-1.5 rounded-xl ring-1 ring-slate-300 dark:ring-slate-700 text-sm self-start md:self-auto">Sign out</button>
+            </div>
+            <div class="px-6 md:px-8 pt-6 border-b border-slate-200/50 dark:border-slate-700/50 space-y-4">
+              <div>
+                <label class="block text-sm font-semibold mb-2">🏫 Class</label>
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <select id="classSelect" class="w-full sm:flex-1 rounded-2xl bg-slate-50/80 dark:bg-slate-800/80 border-2 border-slate-200/60 dark:border-slate-700/60 px-4 py-3 text-sm focus:border-emerald-500 focus:ring-0" aria-label="Select class">
+                    <option value="" disabled selected>Loading classes…</option>
+                  </select>
+                  <div class="flex flex-wrap gap-2">
+                    <button id="newClassBtn" type="button" class="px-4 py-2 rounded-2xl bg-gradient-to-r from-emerald-500 to-teal-500 text-white text-sm font-semibold shadow">➕ New class</button>
+                    <button id="joinClassBtn" type="button" class="px-4 py-2 rounded-2xl bg-slate-200/80 dark:bg-slate-700/80 text-slate-700 dark:text-slate-200 text-sm font-semibold border border-slate-300/40 dark:border-slate-600/40">🔑 Join class</button>
+                  </div>
+                </div>
+                <p id="classHint" class="mt-2 text-xs text-slate-500 dark:text-slate-400">Create or join a class to manage its own notes database.</p>
+              </div>
+              <div>
+                <div class="flex items-center justify-between gap-3 mb-2">
+                  <span class="block text-sm font-semibold">👥 Students</span>
+                  <button id="addStudentBtn" type="button" class="px-3 py-1.5 rounded-xl bg-gradient-to-r from-blue-500 to-indigo-500 text-white text-xs font-semibold shadow">➕ Add student</button>
+                </div>
+                <div id="studentsChips" class="flex flex-wrap gap-2 text-xs text-slate-600 dark:text-slate-400">
+                  <span class="px-3 py-1 rounded-full bg-slate-200/60 dark:bg-slate-800/60">No class selected.</span>
+                </div>
+              </div>
             </div>
             <form id="notesForm" class="p-6 md:p-8 space-y-6">
               <div>
@@ -127,7 +154,7 @@
               </div>
             </div>
             <div class="overflow-hidden">
-              <div class="overflow-x-auto custom-scrollbar max-h-96">
+              <div class="overflow-x-auto custom-scrollbar max-h-[75vh]">
                 <table class="min-w-full text-left text-sm">
                   <thead class="sticky top-0 backdrop-blur bg-slate-100/90 dark:bg-slate-800/90">
                     <tr>
@@ -205,7 +232,7 @@
 
       <footer class="mt-12 text-center">
         <div class="glass bg-white/60 dark:bg-slate-800/60 rounded-2xl px-6 py-4 inline-block">
-          <p class="text-xs text-slate-600 dark:text-slate-400">🔒 Data: <span class="font-mono font-semibold">classes/Attari/notes</span> • Unique per <em>date + student</em></p>
+          <p class="text-xs text-slate-600 dark:text-slate-400">🔒 Data: <span id="classPathLabel" class="font-mono font-semibold">classes/—</span> • Unique per <em>date + student</em></p>
         </div>
       </footer>
     </div>
@@ -215,7 +242,7 @@
   <script type="module">
     import { initializeApp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-app.js";
     import { getAuth, onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-auth.js";
-    import { getFirestore, collection, doc, setDoc, getDoc, getDocs, deleteDoc, query, orderBy, where, limit as qLimit, onSnapshot, serverTimestamp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-firestore.js";
+    import { getFirestore, collection, doc, setDoc, getDoc, getDocs, deleteDoc, updateDoc, query, orderBy, where, limit as qLimit, onSnapshot, serverTimestamp, arrayUnion } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-firestore.js";
 
     const firebaseConfig = { apiKey:"AIzaSyCTGIoNNey_0GwRxg_85Xv-jEQtQDjzehw", authDomain:"attari-579d2.firebaseapp.com", projectId:"attari-579d2", storageBucket:"attari-579d2.firebasestorage.app", messagingSenderId:"765966619098", appId:"1:765966619098:web:9ab852c4881426472b70e3" };
 
@@ -243,9 +270,17 @@
     signOutBtn?.addEventListener('click', ()=>signOut(auth));
 
     // Students and elements
-    const students=["Siyaam Azar","Hussain Ali","Hamza Razzaq","Subhan Hussain","Milad Raza","Murtaza Arfan","Zeeshan Hussain","Mohammed Subhan Ramzan","Onees Usman","Mohammed Hassan Hussain","Ali Hussein"];
     const MONTH_LABELS=['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+    const classSelect=document.getElementById('classSelect');
+    const newClassBtn=document.getElementById('newClassBtn');
+    const joinClassBtn=document.getElementById('joinClassBtn');
+    const addStudentBtn=document.getElementById('addStudentBtn');
+    const studentsChips=document.getElementById('studentsChips');
+    const classHint=document.getElementById('classHint');
+    const classStatus=document.getElementById('classStatus');
+    const classPathLabel=document.getElementById('classPathLabel');
     const inputs={student:document.getElementById('student'),quran:document.getElementById('quran'),surah:document.getElementById('surah'),laws:document.getElementById('laws'),qamar:document.getElementById('qamar'),anything:document.getElementById('anything')};
+    const notesForm=document.getElementById('notesForm');
     const filterStudent=document.getElementById('filterStudent');
     const filterDate=document.getElementById('filterDate');
     const historyBody=document.getElementById('historyBody');
@@ -268,38 +303,143 @@
     const reportDownload=document.getElementById('reportDownload');
 
     // Populate selects
-    function populateStudents(){
+    let classStudents=[];
+    let pendingStudentSelection=null;
+    function populateStudents(list){
+      const prevStudent=inputs.student.value;
+      const prevFilterStudent=filterStudent.value;
+      const prevReportStudent=reportStudent.value;
+      const cleaned=Array.isArray(list)?Array.from(new Set(list.map(s=>s?.toString().trim()).filter(Boolean))):[];
+      const sorted=cleaned.sort((a,b)=>a.localeCompare(b,'en',{sensitivity:'base'}));
+      classStudents=sorted;
+
       inputs.student.innerHTML='<option value="" disabled selected>Choose a student…</option>';
-      filterStudent.innerHTML='<option value="">All students</option>';
-      reportStudent.innerHTML='<option value="" disabled selected>Select a student…</option>';
-      students.forEach(n=>{
-        const o=document.createElement('option');o.value=n;o.textContent=n;inputs.student.appendChild(o);
-        const o2=document.createElement('option');o2.value=o.value;o2.textContent=n;filterStudent.appendChild(o2);
-        const o3=document.createElement('option');o3.value=o.value;o3.textContent=n;reportStudent.appendChild(o3);
+      sorted.forEach(name=>{
+        const option=document.createElement('option');
+        option.value=name;
+        option.textContent=name;
+        inputs.student.appendChild(option);
       });
+
+      filterStudent.innerHTML='<option value="">All students</option>';
+      sorted.forEach(name=>{
+        const option=document.createElement('option');
+        option.value=name;
+        option.textContent=name;
+        filterStudent.appendChild(option);
+      });
+
+      reportStudent.innerHTML='<option value="" disabled selected>Select a student…</option>';
+      sorted.forEach(name=>{
+        const option=document.createElement('option');
+        option.value=name;
+        option.textContent=name;
+        reportStudent.appendChild(option);
+      });
+
+      if(pendingStudentSelection&&sorted.includes(pendingStudentSelection)){
+        inputs.student.value=pendingStudentSelection;
+      }else if(prevStudent&&sorted.includes(prevStudent)){
+        inputs.student.value=prevStudent;
+      }
+
+      filterStudent.value=prevFilterStudent&&sorted.includes(prevFilterStudent)?prevFilterStudent:'';
+      reportStudent.value=prevReportStudent&&sorted.includes(prevReportStudent)?prevReportStudent:'';
+      pendingStudentSelection=null;
+
+      const classActive=Boolean(currentClassId);
+      inputs.student.disabled=!classActive||!sorted.length;
+      filterStudent.disabled=!classActive||!sorted.length;
+      reportStudent.disabled=!classActive||!sorted.length;
+      addStudentBtn.disabled=!classActive;
+
+      if(studentsChips){
+        if(sorted.length){
+          studentsChips.innerHTML=sorted.map(name=>`<span class="px-3 py-1 rounded-full bg-slate-200/70 dark:bg-slate-800/70">${esc(name)}</span>`).join('');
+        }else{
+          const emptyLabel=classActive?'No students yet.':'No class selected.';
+          studentsChips.innerHTML=`<span class="px-3 py-1 rounded-full bg-slate-200/60 dark:bg-slate-800/60">${esc(emptyLabel)}</span>`;
+        }
+      }
+
+      const selectedStudent=inputs.student.value;
+      if(classActive&&selectedStudent&&selectedStudent!==prevStudent){
+        maybeLoadTodaysEntry(selectedStudent);
+      }
     }
-    populateStudents();
+
+    function setFormDisabled(disabled){
+      if(disabled){
+        notesForm.classList.add('opacity-60');
+      }else{
+        notesForm.classList.remove('opacity-60');
+      }
+      const elements=notesForm.querySelectorAll('input, textarea, select, button');
+      elements.forEach(el=>{
+        if(el.id==='cancelEditBtn')return;
+        if(el===inputs.student){
+          el.disabled=disabled||!classStudents.length;
+          return;
+        }
+        if(el.id==='saveBtn'){
+          el.disabled=disabled;
+          el.classList.toggle('opacity-60',disabled);
+          el.classList.toggle('cursor-not-allowed',disabled);
+        }else{
+          el.disabled=disabled;
+        }
+      });
+      filterStudent.disabled=disabled||!classStudents.length;
+      filterDate.disabled=disabled;
+      reportStudent.disabled=disabled||!classStudents.length;
+      reportMonth.disabled=disabled;
+      reportFormat.disabled=disabled;
+      reportDownload.disabled=true;
+      addStudentBtn.disabled=disabled||!currentClassId;
+    }
+
+    function updateClassPathLabelText(classId){
+      if(classPathLabel)classPathLabel.textContent=classId?`classes/${classId}/notes`:'classes/—';
+    }
+
+    function updateClassHint(classId,className=''){
+      if(!classHint)return;
+      if(classId){
+        const nameHtml=className?`<span class="font-semibold">${esc(className)}</span> • `:'';
+        classHint.innerHTML=`${nameHtml}Class code: <span class="font-mono font-semibold">${esc(classId)}</span> • Data path <span class="font-mono">classes/${esc(classId)}/notes</span>`;
+      }else{
+        classHint.textContent='Create or join a class to manage its own notes database.';
+      }
+    }
+
+    function updateClassStatus(text){
+      if(classStatus)classStatus.textContent=text;
+    }
 
     const now=new Date();
     const todayKey=toLocalISODate(now);
     document.getElementById('todayDisplay').textContent=formatDisplayDate(todayKey);
     if(reportMonth)reportMonth.value=`${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}`;
 
-    const CLASS_ID='Attari';
-    const notesCol=collection(doc(db,'classes',CLASS_ID),'notes');
-
     const slug=s=>s.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/(^-|-$)/g,'');
     const noteId=(date,student)=>`${date}_${slug(student)}`;
 
     // Edit mode
     let editingKey=null;
-    function setEditMode(n=null){
+    function setEditMode(n=null,{preserveStudent=false}={}){
+      const previousStudent=inputs.student.value;
       if(n){
         editingKey=n.id;
         formTitle.textContent='✏️ Edit Entry';
         saveText.textContent='✅ Update Entry';
         cancelEditBtn.classList.remove('hidden');
-        inputs.student.value=n.student;
+        if(n.student){
+          if(!classStudents.includes(n.student)){
+            pendingStudentSelection=n.student;
+            populateStudents(classStudents);
+          }
+          inputs.student.value=n.student;
+        }
         inputs.quran.value=n.quran||'';
         inputs.surah.value=n.surah||'';
         inputs.laws.value=n.lawsOfSalah||'';
@@ -310,51 +450,80 @@
         formTitle.textContent='✨ New Entry';
         saveText.textContent='💾 Save Entry';
         cancelEditBtn.classList.add('hidden');
-        document.getElementById('notesForm').reset();
+        notesForm.reset();
+        if(preserveStudent&&previousStudent){
+          inputs.student.value=previousStudent;
+        }
       }
     }
-    cancelEditBtn.addEventListener('click',()=>setEditMode(null));
+    cancelEditBtn.addEventListener('click',()=>setEditMode(null,{preserveStudent:true}));
 
     // Save/Update
-    document.getElementById('notesForm').addEventListener('submit',async(e)=>{
+    notesForm.addEventListener('submit',async(e)=>{
       e.preventDefault();
+      if(!currentClassId||!notesColRef){
+        saveStatus.textContent='Select a class first';
+        showToast('Select a class before saving.','error');
+        return;
+      }
       const student=inputs.student.value;
-      if(!student){saveStatus.textContent='Choose a student';return}
+      if(!student){saveStatus.textContent='Choose a student';return;}
       saveSpinner.classList.remove('hidden');
-      const defaultDate=toLocalISODate(new Date());
-      const entryDate=editingKey?extractDateFromId(editingKey)||defaultDate:defaultDate;
-      const id=editingKey||noteId(entryDate,student);
-      const ref=doc(notesCol,id);
-      const payload={
-        id,
-        date:entryDate,
-        student,
-        quran:inputs.quran.value.trim(),
-        surah:inputs.surah.value.trim(),
-        lawsOfSalah:inputs.laws.value.trim(),
-        qamar:inputs.qamar.value.trim(),
-        anythingElse:inputs.anything.value.trim(),
-        updatedAt:serverTimestamp(),
-        ownerUid:auth.currentUser?.uid||null
-      };
-      const snap=await getDoc(ref);
-      if(!snap.exists())payload.createdAt=serverTimestamp();
-      await setDoc(ref,payload,{merge:true});
-      saveSpinner.classList.add('hidden');
-      showToast(editingKey?'Updated ✓':'Saved ✓','success');
-      saveStatus.textContent=editingKey?'Updated ✅':'Saved ✅';
-      setTimeout(()=>saveStatus.textContent='',1200);
-      setEditMode(null);
+      saveBtn.disabled=true;
+      try{
+        const defaultDate=toLocalISODate(new Date());
+        const entryDate=editingKey?extractDateFromId(editingKey)||defaultDate:defaultDate;
+        const id=editingKey||noteId(entryDate,student);
+        const ref=doc(notesColRef,id);
+        const payload={
+          id,
+          date:entryDate,
+          student,
+          quran:inputs.quran.value.trim(),
+          surah:inputs.surah.value.trim(),
+          lawsOfSalah:inputs.laws.value.trim(),
+          qamar:inputs.qamar.value.trim(),
+          anythingElse:inputs.anything.value.trim(),
+          updatedAt:serverTimestamp(),
+          ownerUid:auth.currentUser?.uid||null
+        };
+        const snap=await getDoc(ref);
+        if(!snap.exists())payload.createdAt=serverTimestamp();
+        await setDoc(ref,payload,{merge:true});
+        showToast(editingKey?'Updated ✓':'Saved ✓','success');
+        saveStatus.textContent=editingKey?'Updated ✅':'Saved ✅';
+        setTimeout(()=>saveStatus.textContent='',1200);
+        setEditMode(null,{preserveStudent:true});
+      }catch(err){
+        console.error(err);
+        saveStatus.textContent='Failed to save ❌';
+        showToast('Failed to save note.','error');
+      }finally{
+        saveSpinner.classList.add('hidden');
+        saveBtn.disabled=false;
+      }
     });
 
     // History stream & filters
-    let unsub=null, historyRows=[], currentReportRows=[];
+    let currentUser=null;
+    let currentClassId=null;
+    let currentClassName='';
+    let notesColRef=null;
+    let classesUnsub=null;
+    let classDocUnsub=null;
+    let unsub=null;
+    let historyRows=[];
+    let currentReportRows=[];
     let reportRequestToken=0;
     let jsPdfModulePromise=null;
+    let userClasses=[];
 
     function startHistoryStream(){
       if(unsub)unsub();
-      const q=query(notesCol,orderBy('date','desc'),qLimit(200));
+      historyRows=[];
+      renderHistory([]);
+      if(!notesColRef)return;
+      const q=query(notesColRef,orderBy('date','desc'),qLimit(200));
       unsub=onSnapshot(q,(snap)=>{
         historyRows=snap.docs.map(d=>({id:d.id,...d.data()}));
         applyFilters();
@@ -363,6 +532,10 @@
     }
 
     function applyFilters(){
+      if(!notesColRef){
+        renderHistory([]);
+        return;
+      }
       const s=filterStudent.value;
       const d=filterDate.value;
       let list=historyRows;
@@ -377,19 +550,20 @@
     document.getElementById('reload').addEventListener('click',applyFilters);
 
     async function fetchMonthlyRows(student,range){
+      if(!notesColRef)return [];
       const baseConstraints=[where('date','>=',range.start),where('date','<=',range.end),orderBy('date','asc')];
       const mapSnap=snap=>snap.docs.map(docSnap=>({id:docSnap.id,...docSnap.data()}));
       if(!student){
-        const snap=await getDocs(query(notesCol,...baseConstraints));
+        const snap=await getDocs(query(notesColRef,...baseConstraints));
         return mapSnap(snap);
       }
       try{
-        const snap=await getDocs(query(notesCol,where('student','==',student),...baseConstraints));
+        const snap=await getDocs(query(notesColRef,where('student','==',student),...baseConstraints));
         return mapSnap(snap);
       }catch(err){
         // fallback if composite index is missing
         if(err?.code==='failed-precondition'||/index/i.test(err?.message||'')){
-          const snap=await getDocs(query(notesCol,...baseConstraints));
+          const snap=await getDocs(query(notesColRef,...baseConstraints));
           return mapSnap(snap).filter(r=>r.student===student);
         }
         throw err;
@@ -405,6 +579,23 @@
     });
     renderMonthlyReport();
     updateReportDownloadLabel();
+    populateStudents([]);
+    setFormDisabled(true);
+    updateClassHint(null);
+    updateClassStatus('Select a class to get started.');
+    updateClassPathLabelText(null);
+    renderClassSelect(null);
+
+    classSelect?.addEventListener('change',()=>{
+      const value=classSelect.value;
+      if(value){
+        setCurrentClass(value);
+      }
+    });
+    newClassBtn?.addEventListener('click',handleCreateClass);
+    joinClassBtn?.addEventListener('click',handleJoinClass);
+    addStudentBtn?.addEventListener('click',handleAddStudent);
+    inputs.student.addEventListener('change',()=>maybeLoadTodaysEntry(inputs.student.value));
 
     function renderHistory(rows){
       historyBody.innerHTML='';
@@ -448,6 +639,11 @@
       }
       reportTableWrapper.classList.add('hidden');
       reportEmpty.classList.remove('hidden');
+
+      if(!notesColRef){
+        reportEmptyText.textContent='Select a class to see monthly reports.';
+        return;
+      }
 
       if(!student){reportEmptyText.textContent='Select a student to see their monthly report.';return;}
       if(!monthValue){reportEmptyText.textContent='Choose a month to view the report.';return;}
@@ -502,7 +698,7 @@
     }
 
     async function downloadMonthlyReport(){
-      if(!currentReportRows.length||!reportStudent||!reportMonth||!reportDownload)return;
+      if(!notesColRef||!currentReportRows.length||!reportStudent||!reportMonth||!reportDownload)return;
       const student=reportStudent.value;
       const monthValue=reportMonth.value;
       if(!student||!monthValue)return;
@@ -655,29 +851,297 @@
       return jsPdfModulePromise;
     }
 
+    function renderClassSelect(selectedId){
+      if(!classSelect)return;
+      classSelect.innerHTML='';
+      if(!currentUser){
+        const option=document.createElement('option');
+        option.value='';
+        option.textContent='Sign in to load classes…';
+        option.disabled=true;
+        option.selected=true;
+        classSelect.appendChild(option);
+        classSelect.disabled=true;
+        return;
+      }
+      if(!userClasses.length){
+        const option=document.createElement('option');
+        option.value='';
+        option.textContent='No classes yet';
+        option.disabled=true;
+        option.selected=true;
+        classSelect.appendChild(option);
+        classSelect.disabled=true;
+        return;
+      }
+      const placeholder=document.createElement('option');
+      placeholder.value='';
+      placeholder.textContent='Select a class…';
+      placeholder.disabled=true;
+      classSelect.appendChild(placeholder);
+      userClasses.forEach(cls=>{
+        const option=document.createElement('option');
+        option.value=cls.id;
+        option.textContent=cls.name||cls.id;
+        classSelect.appendChild(option);
+      });
+      classSelect.disabled=false;
+      if(selectedId&&userClasses.some(c=>c.id===selectedId)){
+        classSelect.value=selectedId;
+      }else if(currentClassId&&userClasses.some(c=>c.id===currentClassId)){
+        classSelect.value=currentClassId;
+      }else if(userClasses.length){
+        classSelect.value=userClasses[0].id;
+      }else{
+        placeholder.selected=true;
+      }
+    }
+
+    function watchUserClasses(uid){
+      if(classesUnsub){classesUnsub();classesUnsub=null;}
+      userClasses=[];
+      renderClassSelect(null);
+      if(!uid){
+        setCurrentClass(null);
+        return;
+      }
+      const classesRef=collection(db,'classes');
+      const classesQuery=query(classesRef,where('members','array-contains',uid));
+      classesUnsub=onSnapshot(classesQuery,(snap)=>{
+        userClasses=snap.docs.map(docSnap=>({id:docSnap.id,...docSnap.data()})).sort((a,b)=>{
+          const nameA=(a.name||a.id||'').toLowerCase();
+          const nameB=(b.name||b.id||'').toLowerCase();
+          return nameA.localeCompare(nameB);
+        });
+        const availableIds=userClasses.map(c=>c.id);
+        let desired=null;
+        if(currentClassId&&availableIds.includes(currentClassId)){
+          desired=currentClassId;
+        }else if(availableIds.length){
+          desired=availableIds[0];
+        }
+        renderClassSelect(desired);
+        if(desired!==currentClassId){
+          setCurrentClass(desired||null);
+        }else if(!desired){
+          setCurrentClass(null);
+        }
+      },(err)=>{
+        console.error('Failed to load classes',err);
+        showToast('Unable to load classes','error');
+      });
+    }
+
+    function resetAppState(){
+      if(unsub){unsub();unsub=null;}
+      if(classDocUnsub){classDocUnsub();classDocUnsub=null;}
+      notesColRef=null;
+      currentClassId=null;
+      currentClassName='';
+      userClasses=[];
+      historyRows=[];
+      currentReportRows=[];
+      reportInfo.textContent='';
+      renderHistory([]);
+      reportTableWrapper.classList.add('hidden');
+      reportEmpty.classList.remove('hidden');
+      reportEmptyText.textContent='Select a class to see monthly reports.';
+      filterStudent.value='';
+      filterDate.value='';
+      if(reportStudent)reportStudent.value='';
+      pendingStudentSelection=null;
+      setEditMode(null);
+      populateStudents([]);
+      setFormDisabled(true);
+      updateClassPathLabelText(null);
+      updateClassHint(null);
+      updateClassStatus('Select a class to get started.');
+      updateReportDownloadLabel();
+    }
+
+    function setCurrentClass(classId){
+      if(classId===currentClassId)return;
+      if(unsub){unsub();unsub=null;}
+      if(classDocUnsub){classDocUnsub();classDocUnsub=null;}
+      currentClassId=classId||null;
+      currentClassName='';
+      notesColRef=null;
+      historyRows=[];
+      currentReportRows=[];
+      reportInfo.textContent='';
+      renderHistory([]);
+      saveStatus.textContent='';
+      filterStudent.value='';
+      filterDate.value='';
+      if(reportStudent)reportStudent.value='';
+      pendingStudentSelection=null;
+      updateClassPathLabelText(currentClassId);
+      updateClassHint(currentClassId);
+      if(!currentClassId){
+        setEditMode(null);
+        populateStudents([]);
+        setFormDisabled(true);
+        updateClassStatus(userClasses.length?'Select a class to get started.':'No classes yet — create or join one.');
+        reportEmptyText.textContent='Select a class to see monthly reports.';
+        return;
+      }
+      if(classSelect&&classSelect.value!==currentClassId){
+        classSelect.value=currentClassId;
+      }
+      const classRef=doc(db,'classes',currentClassId);
+      notesColRef=collection(classRef,'notes');
+      setEditMode(null);
+      setFormDisabled(false);
+      updateClassStatus('Loading class…');
+      classDocUnsub=onSnapshot(classRef,(snap)=>{
+        if(!snap.exists()){
+          updateClassStatus('Class not found.');
+          populateStudents([]);
+          setFormDisabled(true);
+          if(classHint)classHint.textContent='This class does not exist yet. Create it to get started.';
+          return;
+        }
+        const data=snap.data();
+        currentClassName=data.name||currentClassId;
+        updateClassStatus(`Working in ${currentClassName}`);
+        updateClassHint(currentClassId,currentClassName);
+        populateStudents(data.students||[]);
+      },(err)=>{
+        console.error('Failed to load class',err);
+        showToast('Unable to load class','error');
+      });
+      reportEmptyText.textContent='Select a student to see their monthly report.';
+      startHistoryStream();
+      applyFilters();
+      renderMonthlyReport();
+    }
+
+    async function handleCreateClass(){
+      if(!currentUser){showToast('Sign in to create a class.','error');return;}
+      const name=prompt('Name for the new class?');
+      if(name===null)return;
+      const trimmed=name.trim();
+      if(!trimmed){showToast('Class name is required.','error');return;}
+      const id=slug(trimmed);
+      if(!id){showToast('Class name must include letters or numbers.','error');return;}
+      const classRef=doc(db,'classes',id);
+      try{
+        const snap=await getDoc(classRef);
+        if(snap.exists()){
+          await updateDoc(classRef,{members:arrayUnion(currentUser.uid),name:snap.data()?.name||trimmed});
+          showToast('Joined existing class ✓','success');
+        }else{
+          await setDoc(classRef,{name:trimmed,createdAt:serverTimestamp(),ownerUid:currentUser.uid,members:[currentUser.uid],students:[]});
+          showToast('Class created ✓','success');
+        }
+        setCurrentClass(id);
+      }catch(err){
+        console.error(err);
+        showToast('Unable to create class','error');
+      }
+    }
+
+    async function handleJoinClass(){
+      if(!currentUser){showToast('Sign in to join a class.','error');return;}
+      const code=prompt('Enter the class code to join');
+      if(code===null)return;
+      const trimmed=code.trim();
+      if(!trimmed){showToast('Class code is required.','error');return;}
+      let classId=trimmed;
+      let classRef=doc(db,'classes',classId);
+      let snap=await getDoc(classRef);
+      if(!snap.exists()){
+        const normalized=slug(trimmed);
+        if(normalized){
+          classId=normalized;
+          classRef=doc(db,'classes',classId);
+          snap=await getDoc(classRef);
+        }
+      }
+      if(!snap.exists()){
+        showToast('Class not found.','error');
+        return;
+      }
+      try{
+        await updateDoc(classRef,{members:arrayUnion(currentUser.uid)});
+        showToast('Joined class ✓','success');
+        setCurrentClass(classId);
+      }catch(err){
+        console.error(err);
+        showToast('Unable to join class.','error');
+      }
+    }
+
+    async function handleAddStudent(){
+      if(!currentClassId){showToast('Select a class first.','error');return;}
+      const name=prompt('Student name');
+      if(name===null)return;
+      const trimmed=name.trim();
+      if(!trimmed){showToast('Student name is required.','error');return;}
+      if(classStudents.some(s=>s.toLowerCase()===trimmed.toLowerCase())){
+        showToast('Student already exists.','error');
+        return;
+      }
+      const classRef=doc(db,'classes',currentClassId);
+      try{
+        pendingStudentSelection=trimmed;
+        await updateDoc(classRef,{students:arrayUnion(trimmed)});
+        showToast('Student added ✓','success');
+      }catch(err){
+        console.error(err);
+        showToast('Unable to add student.','error');
+      }
+    }
+
+    async function maybeLoadTodaysEntry(student){
+      if(!student||!notesColRef)return;
+      const expectedClassId=currentClassId;
+      const selectionToken=student;
+      const today=toLocalISODate(new Date());
+      const id=noteId(today,student);
+      try{
+        const snap=await getDoc(doc(notesColRef,id));
+        if(currentClassId!==expectedClassId)return;
+        if(inputs.student.value!==selectionToken)return;
+        if(snap.exists()){
+          setEditMode({...snap.data(),id:snap.id});
+        }else if(editingKey){
+          setEditMode(null,{preserveStudent:true});
+        }
+      }catch(err){
+        console.error('Failed to load daily entry',err);
+      }
+    }
+
     historyBody.addEventListener('click',async(e)=>{
       const btn=e.target.closest('button'); if(!btn) return;
+      if(!notesColRef)return;
       const id=btn.getAttribute('data-id');
       if(btn.getAttribute('data-action')==='edit'){
-        const snap=await getDoc(doc(notesCol,id));
-        if(snap.exists()) setEditMode(snap.data());
+        const snap=await getDoc(doc(notesColRef,id));
+        if(snap.exists()) setEditMode({id:snap.id,...snap.data()});
       } else if(btn.getAttribute('data-action')==='delete'){
         if(!confirm('Delete this note?')) return;
-        await deleteDoc(doc(notesCol,id));
+        await deleteDoc(doc(notesColRef,id));
         showToast('Deleted','success');
       }
     });
 
     // Auth gate
     onAuthStateChanged(auth,(user)=>{
+      currentUser=user||null;
       if(user){
         authGate.classList.add('hidden');
         appShell.classList.remove('hidden');
         whoami.textContent=user.email||user.uid;
         authStatus.textContent='Online';
         dot.className='w-2 h-2 rounded-full bg-emerald-400';
-        startHistoryStream();
+        updateClassStatus('Loading classes…');
+        watchUserClasses(user.uid);
       } else {
+        if(classesUnsub){classesUnsub();classesUnsub=null;}
+        resetAppState();
+        renderClassSelect(null);
         appShell.classList.add('hidden');
         authGate.classList.remove('hidden');
         whoami.textContent='Not signed in';


### PR DESCRIPTION
## Summary
- allow teachers to create or join classes, populate per-class student lists, and surface the active Firestore path
- refactor note saving and reporting logic to use the selected class, including automatic loading of today’s entry when a student is chosen
- refresh the layout with embedded class controls, student chips, and a taller history table to reduce scrolling

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d64f2da744832eac9288f804161aa4