### PR TITLE
Scope notes operations to per-class Firestore collections

### DIFF
--- a/Attari.html
+++ b/Attari.html
@@ -232,7 +232,7 @@
 
       <footer class="mt-12 text-center">
         <div class="glass bg-white/60 dark:bg-slate-800/60 rounded-2xl px-6 py-4 inline-block">
-          <p class="text-xs text-slate-600 dark:text-slate-400">🔒 Data: <span id="classPathLabel" class="font-mono font-semibold">classes/—</span> • Unique per <em>date + student</em></p>
+          <p class="text-xs text-slate-600 dark:text-slate-400">🔒 Data: <span id="classPathLabel" class="font-mono font-semibold">classes/—/notes</span> • Unique per <em>date + student</em></p>
         </div>
       </footer>
     </div>
@@ -399,16 +399,17 @@
     }
 
     function updateClassPathLabelText(classId){
-      if(classPathLabel)classPathLabel.textContent=classId?`classes/${classId}/notes`:'classes/—';
+      if(classPathLabel)classPathLabel.textContent=classId?`classes/${classId}/notes`:'classes/—/notes';
     }
 
     function updateClassHint(classId,className=''){
       if(!classHint)return;
       if(classId){
         const nameHtml=className?`<span class="font-semibold">${esc(className)}</span> • `:'';
-        classHint.innerHTML=`${nameHtml}Class code: <span class="font-mono font-semibold">${esc(classId)}</span> • Data path <span class="font-mono">classes/${esc(classId)}/notes</span>`;
+        const rulesHtml=`<span class="block text-[0.7rem] text-slate-500 dark:text-slate-400 mt-1">Firestore rule: <span class="font-mono">match /classes/{classId}/notes/{noteId}</span></span>`;
+        classHint.innerHTML=`${nameHtml}Class code: <span class="font-mono font-semibold">${esc(classId)}</span> • Data path <span class="font-mono">classes/${esc(classId)}/notes</span>${rulesHtml}`;
       }else{
-        classHint.textContent='Create or join a class to manage its own notes database.';
+        classHint.innerHTML='Create or join a class to manage its own notes database.<span class="block text-[0.7rem] text-slate-500 dark:text-slate-400 mt-1">Firestore rule: <span class="font-mono">match /classes/{classId}/notes/{noteId}</span></span>';
       }
     }
 
@@ -461,7 +462,8 @@
     // Save/Update
     notesForm.addEventListener('submit',async(e)=>{
       e.preventDefault();
-      if(!currentClassId||!notesColRef){
+      const notesRef=getClassNotesCollection();
+      if(!currentClassId||!notesRef){
         saveStatus.textContent='Select a class first';
         showToast('Select a class before saving.','error');
         return;
@@ -474,7 +476,7 @@
         const defaultDate=toLocalISODate(new Date());
         const entryDate=editingKey?extractDateFromId(editingKey)||defaultDate:defaultDate;
         const id=editingKey||noteId(entryDate,student);
-        const ref=doc(notesColRef,id);
+        const ref=doc(notesRef,id);
         const payload={
           id,
           date:entryDate,
@@ -508,7 +510,6 @@
     let currentUser=null;
     let currentClassId=null;
     let currentClassName='';
-    let notesColRef=null;
     let classesUnsub=null;
     let classDocUnsub=null;
     let unsub=null;
@@ -518,12 +519,22 @@
     let jsPdfModulePromise=null;
     let userClasses=[];
 
+    function getClassDocRef(classId=currentClassId){
+      return classId?doc(db,'classes',classId):null;
+    }
+
+    function getClassNotesCollection(classId=currentClassId){
+      const classRef=getClassDocRef(classId);
+      return classRef?collection(classRef,'notes'):null;
+    }
+
     function startHistoryStream(){
       if(unsub)unsub();
       historyRows=[];
       renderHistory([]);
-      if(!notesColRef)return;
-      const q=query(notesColRef,orderBy('date','desc'),qLimit(200));
+      const notesRef=getClassNotesCollection();
+      if(!notesRef)return;
+      const q=query(notesRef,orderBy('date','desc'),qLimit(200));
       unsub=onSnapshot(q,(snap)=>{
         historyRows=snap.docs.map(d=>({id:d.id,...d.data()}));
         applyFilters();
@@ -532,7 +543,7 @@
     }
 
     function applyFilters(){
-      if(!notesColRef){
+      if(!getClassNotesCollection()){
         renderHistory([]);
         return;
       }
@@ -550,20 +561,21 @@
     document.getElementById('reload').addEventListener('click',applyFilters);
 
     async function fetchMonthlyRows(student,range){
-      if(!notesColRef)return [];
+      const notesRef=getClassNotesCollection();
+      if(!notesRef)return [];
       const baseConstraints=[where('date','>=',range.start),where('date','<=',range.end),orderBy('date','asc')];
       const mapSnap=snap=>snap.docs.map(docSnap=>({id:docSnap.id,...docSnap.data()}));
       if(!student){
-        const snap=await getDocs(query(notesColRef,...baseConstraints));
+        const snap=await getDocs(query(notesRef,...baseConstraints));
         return mapSnap(snap);
       }
       try{
-        const snap=await getDocs(query(notesColRef,where('student','==',student),...baseConstraints));
+        const snap=await getDocs(query(notesRef,where('student','==',student),...baseConstraints));
         return mapSnap(snap);
       }catch(err){
         // fallback if composite index is missing
         if(err?.code==='failed-precondition'||/index/i.test(err?.message||'')){
-          const snap=await getDocs(query(notesColRef,...baseConstraints));
+          const snap=await getDocs(query(notesRef,...baseConstraints));
           return mapSnap(snap).filter(r=>r.student===student);
         }
         throw err;
@@ -640,7 +652,7 @@
       reportTableWrapper.classList.add('hidden');
       reportEmpty.classList.remove('hidden');
 
-      if(!notesColRef){
+      if(!getClassNotesCollection()){
         reportEmptyText.textContent='Select a class to see monthly reports.';
         return;
       }
@@ -698,7 +710,7 @@
     }
 
     async function downloadMonthlyReport(){
-      if(!notesColRef||!currentReportRows.length||!reportStudent||!reportMonth||!reportDownload)return;
+      if(!getClassNotesCollection()||!currentReportRows.length||!reportStudent||!reportMonth||!reportDownload)return;
       const student=reportStudent.value;
       const monthValue=reportMonth.value;
       if(!student||!monthValue)return;
@@ -935,7 +947,6 @@
     function resetAppState(){
       if(unsub){unsub();unsub=null;}
       if(classDocUnsub){classDocUnsub();classDocUnsub=null;}
-      notesColRef=null;
       currentClassId=null;
       currentClassName='';
       userClasses=[];
@@ -965,7 +976,6 @@
       if(classDocUnsub){classDocUnsub();classDocUnsub=null;}
       currentClassId=classId||null;
       currentClassName='';
-      notesColRef=null;
       historyRows=[];
       currentReportRows=[];
       reportInfo.textContent='';
@@ -988,8 +998,7 @@
       if(classSelect&&classSelect.value!==currentClassId){
         classSelect.value=currentClassId;
       }
-      const classRef=doc(db,'classes',currentClassId);
-      notesColRef=collection(classRef,'notes');
+      const classRef=getClassDocRef(currentClassId);
       setEditMode(null);
       setFormDisabled(false);
       updateClassStatus('Loading class…');
@@ -1094,13 +1103,15 @@
     }
 
     async function maybeLoadTodaysEntry(student){
-      if(!student||!notesColRef)return;
+      if(!student)return;
+      const notesRef=getClassNotesCollection();
+      if(!notesRef)return;
       const expectedClassId=currentClassId;
       const selectionToken=student;
       const today=toLocalISODate(new Date());
       const id=noteId(today,student);
       try{
-        const snap=await getDoc(doc(notesColRef,id));
+        const snap=await getDoc(doc(notesRef,id));
         if(currentClassId!==expectedClassId)return;
         if(inputs.student.value!==selectionToken)return;
         if(snap.exists()){
@@ -1115,14 +1126,15 @@
 
     historyBody.addEventListener('click',async(e)=>{
       const btn=e.target.closest('button'); if(!btn) return;
-      if(!notesColRef)return;
+      const notesRef=getClassNotesCollection();
+      if(!notesRef)return;
       const id=btn.getAttribute('data-id');
       if(btn.getAttribute('data-action')==='edit'){
-        const snap=await getDoc(doc(notesColRef,id));
+        const snap=await getDoc(doc(notesRef,id));
         if(snap.exists()) setEditMode({id:snap.id,...snap.data()});
       } else if(btn.getAttribute('data-action')==='delete'){
         if(!confirm('Delete this note?')) return;
-        await deleteDoc(doc(notesColRef,id));
+        await deleteDoc(doc(notesRef,id));
         showToast('Deleted','success');
       }
     });


### PR DESCRIPTION
## Summary
- derive class-specific Firestore references via helpers and update all note CRUD, history, and report flows to use them
- refresh the UI hint/path labels to show `classes/{classId}/notes` and surface the matching security rule path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67546b75c832ebb6e0b441c1ab278